### PR TITLE
Update: Set specific background image

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,21 @@ $ go get github.com/Iwark/text2img
 
 ### Binary
 
+When using a random color background image:
+
 ```
 $ text2img -fontpath="fonts/font.ttf" -output="test.jpg" -text="text2img generates the image from a text"
 ```
+
+Using a specific image file:
+
+```
+$ text2img -fontpath="fonts/font.ttf" -output="test.jpg" -text="text2img generates the image from a text" -bgimg="gophers.jpg"
+```
+
+![bgimgEx](https://i.imgur.com/MWNV44f.jpg)
+
+([The Go gopher](https://blog.golang.org/gopher) was designed by [Renée French.](http://reneefrench.blogspot.com/))
 
 ### Go code
 

--- a/cmd/text2img/main.go
+++ b/cmd/text2img/main.go
@@ -9,13 +9,15 @@ import (
 )
 
 var fontPath = flag.String("fontpath", "", "path to the font")
+var backgroundImagePath = flag.String("bgimg", "", "path to the background image")
 var output = flag.String("output", "image.jpg", "path to the output image")
 var text = flag.String("text", "", "text to draw")
 
 func main() {
 	flag.Parse()
 	d, err := text2img.NewDrawer(text2img.Params{
-		FontPath: *fontPath,
+		FontPath:            *fontPath,
+		BackgroundImagePath: *backgroundImagePath,
 	})
 	if err != nil {
 		panic(err.Error())

--- a/drawer.go
+++ b/drawer.go
@@ -6,6 +6,7 @@ import (
 	"image/color"
 	"image/draw"
 	"io/ioutil"
+	"os"
 
 	"github.com/golang/freetype"
 	"github.com/golang/freetype/truetype"
@@ -24,12 +25,13 @@ type Drawer interface {
 
 // Params is parameters for NewDrawer function
 type Params struct {
-	Width           int
-	Height          int
-	FontPath        string
-	FontSize        float64
-	BackgroundColor color.RGBA
-	TextColor       color.RGBA
+	Width               int
+	Height              int
+	FontPath            string
+	BackgroundImagePath string
+	FontSize            float64
+	BackgroundColor     color.RGBA
+	TextColor           color.RGBA
 }
 
 // NewDrawer returns Drawer interface
@@ -50,6 +52,7 @@ func NewDrawer(params Params) (Drawer, error) {
 
 type drawer struct {
 	BackgroundColor *image.Uniform
+	BackgroundImage *image.Image
 	Font            *truetype.Font
 	FontSize        float64
 	Height          int
@@ -92,6 +95,20 @@ func (d *drawer) Draw(text string) (img *image.RGBA, err error) {
 	// 	Dot:  point,
 	// }
 	// fd.DrawString(text)
+	return
+}
+
+func (d *drawer) SetBackgroundImage(imagePath string) (err error) {
+	src, err := os.Open("./sample.png")
+	if err != nil {
+		return
+	}
+
+	img, _, err := image.Decode(src)
+	if err != nil {
+		return
+	}
+	d.BackgroundImage = &img
 	return
 }
 

--- a/drawer.go
+++ b/drawer.go
@@ -115,6 +115,7 @@ func (d *drawer) Draw(text string) (img *image.RGBA, err error) {
 	return
 }
 
+// SetBackgroundImage sets the specific background image
 func (d *drawer) SetBackgroundImage(imagePath string) (err error) {
 	src, err := os.Open(imagePath)
 	if err != nil {


### PR DESCRIPTION
This PR makes it possible to choose background image using `bgimg` option.

For example:  

command:
`text2img -fontpath="fonts/font.ttf" -output="test.jpg" -text="kawaii gopher" -bgimg="gophers.jpg"`

result:
![test](https://user-images.githubusercontent.com/29294540/46916761-d14b9d00-cff9-11e8-9d78-0a564643a5ae.jpg)
([The Go gopher](https://blog.golang.org/gopher) was designed by [Renée French.](http://reneefrench.blogspot.com/))